### PR TITLE
Remove static IP setting

### DIFF
--- a/proxmox/vm/main.tf
+++ b/proxmox/vm/main.tf
@@ -49,7 +49,6 @@ resource "proxmox_virtual_environment_vm" "vm_resource" {
   }
 
   initialization {
-    user_data_file_id = proxmox_virtual_environment_file.cloud_config.id
     # Available attributes:
     # datastore_id      = "local-lvm"
     # interface         = "ide2"
@@ -57,9 +56,14 @@ resource "proxmox_virtual_environment_vm" "vm_resource" {
     # user_data_file_id = "sdd:snippets/cloud-config.yaml"
     ip_config {
       ipv4 {
-        address = "dhcp"
+        address = var.ipv4_address
+        # 'gateway' must be omitted because it's optional, and
+        # it doesn't work when `address = "ducp"`
+        # gateway = ""
       }
     }
+
+    user_data_file_id = proxmox_virtual_environment_file.cloud_config.id
   }
 
   network_device {

--- a/proxmox/vm/main.tf
+++ b/proxmox/vm/main.tf
@@ -56,10 +56,7 @@ resource "proxmox_virtual_environment_vm" "vm_resource" {
     # user_data_file_id = "sdd:snippets/cloud-config.yaml"
     ip_config {
       ipv4 {
-        address = var.ipv4_address
-        # 'gateway' must be omitted because it's optional, and
-        # it doesn't work when `address = "ducp"`
-        # gateway = ""
+        address = "dhcp"
       }
     }
 

--- a/proxmox/vm/main.tf
+++ b/proxmox/vm/main.tf
@@ -49,6 +49,7 @@ resource "proxmox_virtual_environment_vm" "vm_resource" {
   }
 
   initialization {
+    user_data_file_id = proxmox_virtual_environment_file.cloud_config.id
     # Available attributes:
     # datastore_id      = "local-lvm"
     # interface         = "ide2"
@@ -56,14 +57,9 @@ resource "proxmox_virtual_environment_vm" "vm_resource" {
     # user_data_file_id = "sdd:snippets/cloud-config.yaml"
     ip_config {
       ipv4 {
-        address = var.ipv4_address
-        # 'gateway' must be omitted because it's optional, and
-        # it doesn't work when `address = "ducp"`
-        # gateway = ""
+        address = "dhcp"
       }
     }
-
-    user_data_file_id = proxmox_virtual_environment_file.cloud_config.id
   }
 
   network_device {

--- a/proxmox/vm/vars.tf
+++ b/proxmox/vm/vars.tf
@@ -48,6 +48,11 @@ variable "disk_interface" {
   description = "Storage disk interface. Default value: `scsi0`."
 }
 
+variable "ipv4_address" {
+  type        = string
+  description = "IPv4 in the IP/CIDR format. For example: 192.168.5.25/24."
+}
+
 variable "network_interface" {
   default     = "vmbr0"
   type        = string

--- a/proxmox/vm/vars.tf
+++ b/proxmox/vm/vars.tf
@@ -48,11 +48,6 @@ variable "disk_interface" {
   description = "Storage disk interface. Default value: `scsi0`."
 }
 
-variable "ipv4_address" {
-  type        = string
-  description = "IPv4 in the IP/CIDR format. For example: 192.168.5.25/24."
-}
-
 variable "network_interface" {
   default     = "vmbr0"
   type        = string


### PR DESCRIPTION
## Summary 
Setting the DHCP IP as static has limitations with the bpg/proxmox provider. The issue arises from the provider's inability to handle setting the value of `initialization.ip_config.ipv4.address` dynamically to switch between a `dhcp` or a static IP (e.g., `10.10.10.44/24`) on demand. This issue stems from the requirement for the `initialization.ip_config.ipv4.gateway` attribute when setting a static IP, which is unnecessary when configuring for `dhcp`. This is paired with the Terraform restriction on setting dynamic variables to control the module's attributes.


Refer to this table:

### Case 1: we want to set a DHCP IP 10.10.10.44/24 (intended to be static in the firewall)

| Values of `initialization.ip_config.ipv4.address` and `initialization.ip_config.ipv4.gateway` | Can get IPv4? | Can get internet? | Notes
| --- | --- | --- | --- |
| `10.10.10.44/24` + gateway IP | ✓ | ✓ |
| `10.10.10.44/24` only (`gateway` is optional) | ✓ | x |

### Case 2: we want to let the VM get a DHCP IP
 
| Values of `initialization.ip_config.ipv4.address` and `initialization.ip_config.ipv4.gateway` | Can get IPv4?      | Can get internet? | Notes
| --- | --- | --- | --- |
| `dhcp` + gateway IP | x | x | Per the bpg/proxmox provider, gateway can't work with `dhcp`
| `dhcp` only (`gateway` is optional) | ✓ | ✓ |

## Solution
Use only `dhcp`. If a static DHCP IP is needed, then copy the VM MAC address from Proxmox UI and configure it as a DHCP static lease in your firewall.