### PR TITLE
Remove file resource

### DIFF
--- a/proxmox/vm/main.tf
+++ b/proxmox/vm/main.tf
@@ -44,7 +44,7 @@ resource "proxmox_virtual_environment_vm" "vm_resource" {
     # size              = 8
     # ssd               = false
     datastore_id = var.disk_name
-    file_id      = proxmox_virtual_environment_download_file.cloud_image_file.id
+    file_id      = "${var.disk_name}:iso/${var.cloud_image_name}"
     interface    = var.disk_interface
   }
 
@@ -116,26 +116,4 @@ resource "proxmox_virtual_environment_file" "cloud_config" {
 
     file_name = "cloud-config.yaml"
   }
-}
-
-/* 
- * The following blocks are workaround for a limitation in Proxmox, which doesn't support
- * writing cloud images with a `.qcow2` extension. This locals block extracts
- * the file name from the URL. The subsequent resource appends `.img` to it.
- * The result will always be an image file name with the `.img` extension, for example,
- * `foo.qcow2.img`. If you download an actual `.img` file, it will be stored as `foo.img.img`.
- *  For more info, refer to the provider's docs:
- *  https://registry.terraform.io/providers/bpg/proxmox/latest/docs/resources/virtual_environment_download_file#file_name
- */
-locals {
-  url_list = split("/", var.cloud_image_url)
-  filename = element(local.url_list, length(local.url_list) - 1)
-}
-
-resource "proxmox_virtual_environment_download_file" "cloud_image_file" {
-  content_type = var.download_file_content_type
-  datastore_id = var.disk_name
-  node_name    = var.proxmox_node_name
-  url          = var.cloud_image_url
-  file_name    = "${local.filename}.img"
 }

--- a/proxmox/vm/vars.tf
+++ b/proxmox/vm/vars.tf
@@ -54,9 +54,9 @@ variable "network_interface" {
   description = "Default node's network device bridge. Default value: `vmbr0`."
 }
 
-variable "cloud_image_url" {
+variable "cloud_image_name" {
   type        = string
-  description = "Cloud image URL. For example, Ubuntu Jammy: `https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img`."
+  description = "Cloud image name. Must end with `.img` extension."
 }
 
 variable "download_file_content_type" {


### PR DESCRIPTION
Removes resource: `proxmox_virtual_environment_download_file`

The downloading of the cloud-image file as a TF resource is being removed because it locks the downloaded file to the same provisioned VM's state. Subsequent attempts to download the same cloud image file on the same disk for a different VM resource result in a Terraform error, as the previous file cannot be overwritten due to being controlled by another Terraform state. This limitation breaks the reusability of the `proxmox/vm` module when used to provision different VM resources.

Instead, the calling child module must provide the name of an already downloaded cloud-image.